### PR TITLE
MRC-1657: Update docker build based on feedback

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2020 Imperial College London
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # naomi.docker
 
+[![Build status](https://badge.buildkite.com/c4c141e7314ac6eb52ab1e8f254a5d335ac1adf0ee2eec3460.svg)](https://buildkite.com/mrc-ide/naomi-dot-docker)
+
 Base image for naomi & hintr docker images.
 
 Builds naomi_base image which contains required packages for naomi & hintr.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
+COPY docker/bin /usr/local/bin/
 COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 RUN install_packages --repo=https://mrc-ide.github.io/drat \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM rocker/r-ver:3.6.0
+FROM rocker/r-ver:4.0.0
 
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install --no-install-recommends \
         libcurl4-openssl-dev \
         libgdal-dev \
         libprotobuf-dev \
@@ -12,10 +12,11 @@ RUN apt-get update && apt-get -y install \
         texinfo \
         texlive \
         texlive-fonts-extra \
-        zlib1g-dev
+        zlib1g-dev \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
 
-COPY docker/bin /usr/local/bin/
-RUN sed  -i'' '/mran.microsoft.com/d' /usr/local/lib/R/etc/Rprofile.site
+COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 RUN install_packages --repo=https://mrc-ide.github.io/drat \
     DiagrammeR \
@@ -56,10 +57,6 @@ RUN install_packages --repo=https://mrc-ide.github.io/drat \
     zip \
     zoo
 
-RUN install_packages --repo=https://inla.r-inla-download.org/R/stable \
-    INLA
-
 RUN install_packages remotes && install_remote \
     bergant/datamodelr \
-    mrc-ide/eppasm \
-    reside-ic/traduire
+    mrc-ide/eppasm

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,0 +1,2 @@
+options(repos = c(CRAN = "https://cloud.r-project.org"),
+        download.file.method = "libcurl")

--- a/docker/clear_docker
+++ b/docker/clear_docker
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-docker kill $(docker ps -aq)
-docker rm $(docker ps -aq)
-docker network prune --force
-exit 0

--- a/docker/common
+++ b/docker/common
@@ -8,13 +8,9 @@ PACKAGE_ORG=mrcide
 # doesn't work
 if [ "$BUILDKITE" = "true" ]; then
     GIT_SHA=${BUILDKITE_COMMIT:0:7}
-else
-    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
-fi
-
-if [ "$BUILDKITE" = "true" ]; then
     GIT_BRANCH=$BUILDKITE_BRANCH
 else
+    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
     GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
 fi
 

--- a/docker/test
+++ b/docker/test
@@ -7,4 +7,4 @@ HERE=$(dirname $0)
 [ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
 
 echo "*** starting container"
-docker run --rm -d $TAG_SHA
+docker run --rm $TAG_SHA


### PR DESCRIPTION
> ## Dockerfile
> 
>  
> 
> * We probably should depend on R version 4 now
> 
>  
> 
> * Best practice for apt installation is apparently:
> 
>  
> 
> ```
> RUN apt-get update && apt-get -y install --no-install-recommends \
>     <packages> \
>     && apt-get clean \
>     && rm -rf /var/lib/apt/lists/*
> ```
> 
>  
> 
> * The lines:
> 
>  
> 
> ```
> COPY docker/bin /usr/local/bin/
> RUN sed  -i'' '/mran.microsoft.com/d' /usr/local/lib/R/etc/Rprofile.site
> ```
> 
>  
> 
> have stopped working for us in the past - see vimc/orderly/docker/Dockerfile for an alternative approach where we just replace the whole Rprofile.site
> 
>  
> 
> * You do not need the last line installing traduire from remotes (and avoiding that will help with API-limits hit by remotes)
> 
>  
> 
> * I thought that we were dropping INLA?
> 
>  
> 
> * I have had mixed (i.e., low) success with RcppEigen compiling correctly in docker - it gets regularly killed due to running out of RAM in orderly container builds
> 
>  
> 
> ## Others
> 
>  
> 
> * Do you want the docker/clear_docker script? Do you use it?
> * The two conditionals in docker/common could be merged
> * The docker/test script looks wrong to me as you start it as a daemon (i.e., backgrounded). So the exit code will always be 0 - at the same time the container will eventually exit as there is no daemon process.
> * Can you please add an MIT licence as LICENSE.md or similar?