### PR TITLE
Remove tmbstan from base packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,6 @@ RUN install_packages --repo=https://mrc-ide.github.io/drat \
     testthat \
     tidyr \
     tidyverse \
-    tmbstan \
     traduire \
     viridis \
     withr \


### PR DESCRIPTION
Now no longer required by model run if https://github.com/mrc-ide/naomi/pull/119 gets merged