### PR TITLE
Notify by email if build fails

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -13,3 +13,7 @@ steps:
     command: docker/push
 
   - wait
+
+notify:
+  - email: "r.ashton@imperial.ac.uk"
+    if: build.state != "passed"


### PR DESCRIPTION
I just noticed the last two scheduled builds failed (due to the eppasm change I mentioned in standup) it would be good if we got some notification for this. Ideally this could ping teams which I think should be possible https://buildkite.com/docs/pipelines/notifications#webhooks but potentially tricky - I just want to put something in for the time being and will create a ticket to notify teams.