### PR TITLE
Install pkgapi using remotes to ensure get most recent version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,6 @@ RUN install_packages --repo=https://mrc-ide.github.io/drat \
         methods \
         mockery \
         mvtnorm \
-        pkgapi \
         plumber \
         ps \
         rdhs \
@@ -74,5 +73,6 @@ RUN install_packages --repo=https://mrc-ide.github.io/drat \
 RUN install_packages remotes && install_remote \
         bergant/datamodelr \
         mrc-ide/eppasm \
+        reside-ic/pkgapi \
         mrc-ide/rrq
 


### PR DESCRIPTION
plumber has been updated and we have updated pkgapi in response but the most recent version isn't being pulled through here because it has not been updated in drat. Move pkgapi to install using remotes to always get the most recent version