### PR TITLE
Add textlive-latex-extra lib

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
         texinfo \
         texlive \
         texlive-fonts-extra \
+        texlive-latex-extra \
         zlib1g-dev \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This will fix the latex warnings found e.g. on this build https://buildkite.com/mrc-ide/hintr/builds/147#a5f12289-412f-4205-a189-e00d0c3e1524/26-182

Not sure exactly what has changed here but some underlying pacakge now requires these, fixed previously for orderly.server e.g. https://github.com/vimc/orderly.server/pull/35/commits/24e752901ddc132739acf9ba941df90807d48b5e