### PR TITLE
Pin duckdb version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,6 @@ RUN install_packages --repo=https://mrc-ide.r-universe.dev \
         data.tree \
         docopt \
         dplyr \
-        duckdb \
         eppasm \
         first90 \
         forcats \
@@ -90,4 +89,5 @@ RUN install_packages --repo=https://mrc-ide.r-universe.dev \
         zoo
 
 RUN install_packages remotes && install_remote \
-        bergant/datamodelr
+        bergant/datamodelr \
+	duckdb/duckdb-r@v0.9.1


### PR DESCRIPTION
Pinning this version because during duckdb development the version of the tool used to read the duckdb file must be the same as that used to write it.

Pinning at 0.9.1 as this is the latest release. Once they have v 1.0.0 deployed is should be backward compatible and we can remove this pin.