### PR TITLE
[NM-39] Create minimal docker base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,69 +1,86 @@
-FROM rhub/r-minimal
+FROM rocker/r-ver:4
 
 ENV PANDOC_VER=2.11.0.2
 
-RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-linux-amd64.tar.gz && \
-    tar xzf pandoc-$PANDOC_VER-linux-amd64.tar.gz && \
-    mv pandoc-$PANDOC_VER/bin/* /usr/local/bin/ && \
-    rm -rf pandoc-$PANDOC_VER*
+RUN apt-get update && apt-get -y install --no-install-recommends \
+        libcurl4-openssl-dev \
+        libgdal-dev \
+        libhiredis-dev \
+        libjq-dev \
+        libprotobuf-dev \
+        libssh-dev \
+        libsodium-dev \
+        libudunits2-dev \
+        libv8-dev \
+        libxml2-dev \
+        protobuf-compiler \
+        texinfo \
+        texlive \
+        texlive-fonts-extra \
+        texlive-latex-extra \
+        wget \
+        xz-utils \
+        zlib1g-dev \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
 
-RUN installr -d \
-    -t "libsodium-dev curl-dev linux-headers openssl-dev gfortran proj-dev gdal-dev sqlite-dev geos-dev udunits-dev protobuf-dev jq-dev libxml2-dev fontconfig-dev xz-utils" \
-    -a "libsodium libssl3 proj gdal geos expat udunits fontconfig jq" \
-    DBI \
-    Matrix \
-    R6 \
-    RcppEigen \
-    TMB \
-    assertthat \
-    brio \
-    callr \
-    data.tree \
-    docopt \
-    dplyr \
-    duckdb \
-    forcats \
-    geojsonio \
-    ggplot2 \
-    glue \
-    gt \
-    jsonlite \
-    knitr \
-    lgr \
-    magrittr \
-    methods \
-    mvtnorm \
-	openxlsx \
-    plotly \
-    plumber \
-    qs \
-    readr \
-    remotes \
-    rlang \
-    rmarkdown \
-    sf \
-    spdep \
-    svglite \
-    tidyr \
-    withr \
-    writexl \
-    yaml \
-    zip \
-    zoo
+## Install pandoc
+RUN cd /opt && wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-1-amd64.deb \
+    && dpkg -i pandoc-$PANDOC_VER-1-amd64.deb \
+    && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /opt/*
 
-# TODO: Install a non-hardcoded version of these
-# I think should be doable by adding R-universe to the repos option via Rprofile
-RUN installr -d \
-    -t "linux-headers" \
-    -a "hiredis-dev" \
-    url::https://mrc-ide.r-universe.dev/src/contrib/rrq_0.7.17.tar.gz \
-    url::https://mrc-ide.r-universe.dev/src/contrib/heartbeatr_0.6.0.tar.gz \
-    url::https://mrc-ide.r-universe.dev/src/contrib/eppasm_0.7.6.tar.gz \
-    url::https://mrc-ide.r-universe.dev/src/contrib/first90_1.6.11.tar.gz \
-    url::https://mrc-ide.r-universe.dev/src/contrib/naomi.options_1.2.1.tar.gz \
-    url::https://mrc-ide.r-universe.dev/src/contrib/porcelain_0.1.15.tar.gz \
-    url::https://mrc-ide.r-universe.dev/src/contrib/specio_0.1.4.tar.gz
+COPY docker/bin /usr/local/bin/
+COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
-RUN apk add binutils \
-    && find / -type f -name "*.so" -exec strip --strip-all {} + || true \
-    && apk del binutils
+RUN install_packages --repo=https://duckdb.r-universe.dev \
+        duckdb
+
+RUN install_packages --repo=https://mrc-ide.r-universe.dev \
+        DBI \
+        Matrix \
+        R6 \
+        RcppEigen \
+        TMB \
+        assertthat \
+        brio \
+        callr \
+        data.tree \
+        docopt \
+        dplyr \
+        eppasm \
+        first90 \
+        forcats \
+        geojsonio \
+        ggplot2 \
+        glue \
+        gt \
+        jsonlite \
+        knitr \
+        lgr \
+        magrittr \
+        methods \
+        mvtnorm \
+        naomi.options \
+        openxlsx \
+        plotly \
+        plumber \
+        porcelain \
+        qs \
+        readr \
+        remotes \
+        rlang \
+        rmarkdown \
+        rrq \
+        sf \
+        spdep \
+        specio \
+        tidyr \
+        traduire \
+        withr \
+        writexl \
+        yaml \
+        zip \
+        zoo
+
+RUN apt-get -y install --no-install-recommends binutils \
+    && find / -type f -name "*.so" -exec strip --strip-all {} + || true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,98 +1,69 @@
-FROM rocker/r-ver:4
+FROM rhub/r-minimal
 
 ENV PANDOC_VER=2.11.0.2
 
-RUN apt-get update && apt-get -y install --no-install-recommends \
-        libcurl4-openssl-dev \
-        libgdal-dev \
-        libhiredis-dev \
-        libjq-dev \
-        libprotobuf-dev \
-        libssh-dev \
-        libsodium-dev \
-        libudunits2-dev \
-        libv8-dev \
-        libxml2-dev \
-        protobuf-compiler \
-        texinfo \
-        texlive \
-        texlive-fonts-extra \
-        texlive-latex-extra \
-        wget \
-        xz-utils \
-        zlib1g-dev \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*
-        
-## Install pandoc
-RUN cd /opt && wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-1-amd64.deb \
-    && dpkg -i pandoc-$PANDOC_VER-1-amd64.deb \
-    && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /opt/*
+RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-linux-amd64.tar.gz && \
+    tar xzf pandoc-$PANDOC_VER-linux-amd64.tar.gz && \
+    mv pandoc-$PANDOC_VER/bin/* /usr/local/bin/ && \
+    rm -rf pandoc-$PANDOC_VER*
 
-COPY docker/bin /usr/local/bin/
-COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
+RUN installr -d \
+    -t "libsodium-dev curl-dev linux-headers openssl-dev gfortran proj-dev gdal-dev sqlite-dev geos-dev udunits-dev protobuf-dev jq-dev libxml2-dev fontconfig-dev xz-utils" \
+    -a "libsodium libssl3 proj gdal geos expat udunits fontconfig jq" \
+    DBI \
+    Matrix \
+    R6 \
+    RcppEigen \
+    TMB \
+    assertthat \
+    brio \
+    callr \
+    data.tree \
+    docopt \
+    dplyr \
+    duckdb \
+    forcats \
+    geojsonio \
+    ggplot2 \
+    glue \
+    gt \
+    jsonlite \
+    knitr \
+    lgr \
+    magrittr \
+    methods \
+    mvtnorm \
+	openxlsx \
+    plotly \
+    plumber \
+    qs \
+    readr \
+    remotes \
+    rlang \
+    rmarkdown \
+    sf \
+    spdep \
+    svglite \
+    tidyr \
+    withr \
+    writexl \
+    yaml \
+    zip \
+    zoo
 
-RUN install_packages --repo=https://duckdb.r-universe.dev \
-        duckdb
+# TODO: Install a non-hardcoded version of these
+# I think should be doable by adding R-universe to the repos option via Rprofile
+RUN installr -d \
+    -t "linux-headers" \
+    -a "hiredis-dev" \
+    url::https://mrc-ide.r-universe.dev/src/contrib/rrq_0.7.17.tar.gz \
+    url::https://mrc-ide.r-universe.dev/src/contrib/heartbeatr_0.6.0.tar.gz \
+    url::https://mrc-ide.r-universe.dev/src/contrib/eppasm_0.7.6.tar.gz \
+    url::https://mrc-ide.r-universe.dev/src/contrib/first90_1.6.11.tar.gz \
+    url::https://mrc-ide.r-universe.dev/src/contrib/naomi.options_1.2.1.tar.gz \
+    url::https://mrc-ide.r-universe.dev/src/contrib/porcelain_0.1.15.tar.gz \
+    url::https://mrc-ide.r-universe.dev/src/contrib/specio_0.1.4.tar.gz
 
-RUN install_packages --repo=https://mrc-ide.r-universe.dev \
-        DBI \
-        DiagrammeR \
-        Matrix \
-        R6 \
-        RcppEigen \
-        TMB \
-        assertthat \
-        covr \
-        data.tree \
-        docopt \
-        dplyr \
-        eppasm \
-        first90 \
-        forcats \
-        geojsonio \
-        ggplot2 \
-        glue \
-        gridExtra \
-        gt \
-        heartbeatr \
-        here \
-        jsonlite \
-        jsonvalidate \
-        knitr \
-        lubridate \
-        magrittr \
-        methods \
-        mockery \
-        mvtnorm \
-        naomi.options \
-        naomi.resources \
-	    openxlsx \
-        plotly \
-        plumber \
-        porcelain \
-        ps \
-        qs \
-        readr \
-        remotes \
-        rlang \
-        rmarkdown \
-        rrq \
-        scales \
-        sf \
-        spdep \
-        specio \
-        survey \
-        testthat \
-        tidyr \
-        tidyverse \
-        traduire \
-        viridis \
-        withr \
-        writexl \
-        yaml \
-        zip \
-        zoo
-
-RUN install_packages remotes && install_remote \
-        bergant/datamodelr
+RUN apk add binutils \
+    && find / -type f -name "*.so" -exec strip --strip-all {} + || true \
+    && apk del binutils


### PR DESCRIPTION
~~Experimenting with a minimal docker image. hintr based off this I got down to <1GB uncompressed ~ 390MB compressed. But it looked like it was performing more slowly. Making a PR for this for visibility purposes and then let's try it out in a real setting.~~

~~If we do see worse performance, some suggestion this might be down to the musl allocator. But I'm not really sure. Couple of things to try~~
1. ~~Build a version from debian-slim, install packages with apt. Would be nice to get this working with pak as r-minimal does. See if this sorts out performance issues~~
2. ~~See if you can change the allocator in the r-minimal base version~~

Scrapping the above, tried with alpine based image but it was significantly slower. This just removed packages not required at run-time. Real slimming of image is done via multistage build in hintr. See discussion there https://github.com/hivtools/hintr/pull/526